### PR TITLE
Feature/bag sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,18 +8,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-
 find_package(cv_bridge REQUIRED)
 find_package(sensor_msgs REQUIRED)
-
 find_package(OpenCV REQUIRED)
+find_package(camera_info_manager REQUIRED)
 
 add_executable(mp4_node
   src/mp4.cpp
@@ -33,6 +28,7 @@ ament_target_dependencies(mp4_node
   rclcpp
   cv_bridge
   sensor_msgs
+  camera_info_manager
 )
 
 install(TARGETS
@@ -49,10 +45,6 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(rclcpp REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(camera_info_manager REQUIRED)
+find_package(camera_calibration_parsers REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -31,7 +31,7 @@ ament_target_dependencies(mp4_node
   rclcpp
   cv_bridge
   sensor_msgs
-  camera_info_manager
+  camera_calibration_parsers
   tf2
   tf2_ros
   geometry_msgs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ find_package(cv_bridge REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(camera_info_manager REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 add_executable(mp4_node
   src/mp4.cpp
@@ -29,6 +32,9 @@ ament_target_dependencies(mp4_node
   cv_bridge
   sensor_msgs
   camera_info_manager
+  tf2
+  tf2_ros
+  geometry_msgs
 )
 
 install(TARGETS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,23 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(EXIV2 REQUIRED exiv2)
+include_directories(${EXIV2_INCLUDE_DIRS})
+link_directories(${EXIV2_LIBRARY_DIRS})
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(OpenCV REQUIRED)
 find_package(camera_calibration_parsers REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(messages_88 REQUIRED)
+
+find_package(OpenCV REQUIRED)
 
 add_executable(mp4_node
   src/mp4.cpp
@@ -25,6 +32,7 @@ add_executable(mp4_node
 
 target_link_libraries(mp4_node 
   ${OpenCV_LIBRARIES}
+  ${EXIV2_LIBRARIES}
 )
 
 ament_target_dependencies(mp4_node
@@ -35,6 +43,7 @@ ament_target_dependencies(mp4_node
   tf2
   tf2_ros
   geometry_msgs
+  messages_88
 )
 
 install(TARGETS

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -1,9 +1,11 @@
 <launch>
     <arg name="video_file" default="my_video.mp4"/>
     <arg name="frame_id" default="mp4"/>
+    <arg name="bag_sync" default="true"/>
 
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">
         <param name="video_file" value="$(var video_file)"/>
         <param name="frame_id" value="$(var frame_id)"/>
+        <param name="bag_sync" value="$(var bag_sync)"/>
     </node>
 </launch>

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -3,6 +3,7 @@
     <arg name="frame_id" default="mp4"/>
     <arg name="bag_sync" default="true"/>
     <arg name="camera_info_file" default="camera_info.yaml"/>
+    <arg name="save_splat_images" default="false"/>
     <arg name="splat_fps" default="5"/>
 
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">
@@ -10,6 +11,7 @@
         <param name="frame_id" value="$(var frame_id)"/>
         <param name="bag_sync" value="$(var bag_sync)"/>
         <param name="camera_info_file" value="$(var camera_info_file)"/>
+        <param name="save_splat_images" value="$(var save_splat_images)"/>
         <param name="splat_fps" value="$(var splat_fps)"/>
     </node>
 </launch>

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -2,10 +2,12 @@
     <arg name="video_file" default="my_video.mp4"/>
     <arg name="frame_id" default="mp4"/>
     <arg name="bag_sync" default="true"/>
+    <arg name="camera_info_file" default="camera_info.yaml"/>
 
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">
         <param name="video_file" value="$(var video_file)"/>
         <param name="frame_id" value="$(var frame_id)"/>
         <param name="bag_sync" value="$(var bag_sync)"/>
+        <param name="camera_info_file" value="$(var camera_info_file)"/>
     </node>
 </launch>

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -1,6 +1,8 @@
 <launch>
     <arg name="video_file" default="my_video.mp4"/>
     <arg name="frame_id" default="mp4"/>
+    <arg name="camera_name" default="mp4"/>
+
     <arg name="bag_sync" default="true"/>
     <arg name="camera_info_file" default="camera_info.yaml"/>
     <arg name="save_splat_images" default="false"/>
@@ -9,6 +11,7 @@
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">
         <param name="video_file" value="$(var video_file)"/>
         <param name="frame_id" value="$(var frame_id)"/>
+        <param name="camera_name" value="$(var camera_name)"/>
         <param name="bag_sync" value="$(var bag_sync)"/>
         <param name="camera_info_file" value="$(var camera_info_file)"/>
         <param name="save_splat_images" value="$(var save_splat_images)"/>

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -3,11 +3,13 @@
     <arg name="frame_id" default="mp4"/>
     <arg name="bag_sync" default="true"/>
     <arg name="camera_info_file" default="camera_info.yaml"/>
+    <arg name="splat_fps" default="5"/>
 
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">
         <param name="video_file" value="$(var video_file)"/>
         <param name="frame_id" value="$(var frame_id)"/>
         <param name="bag_sync" value="$(var bag_sync)"/>
         <param name="camera_info_file" value="$(var camera_info_file)"/>
+        <param name="splat_fps" value="$(var splat_fps)"/>
     </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <depend>rclcpp</depend>
   <depend>cv_bridge</depend>
   <depend>sensor_msgs</depend>
+  <depend>messages_88</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -8,8 +8,53 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/buffer.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include "messages_88/srv/geopoint.hpp"
+
+#include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <exiv2/exiv2.hpp>
+
+using namespace std::chrono_literals;
+
+// Function to embed GPS EXIF data
+void embedGPSData(const std::string& imagePath, double latitude, double longitude, double altitude, rclcpp::Time timestamp) {
+    try {
+        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(imagePath);
+        if (!image.get()) {
+            std::cerr << "Failed to open image for EXIF writing: " << imagePath << std::endl;
+            return;
+        }
+        image->readMetadata();
+        Exiv2::ExifData &exifData = image->exifData();
+
+        // Convert ROS2 Time to human-readable format
+        std::time_t raw_time = timestamp.seconds();
+        struct tm *time_info = std::localtime(&raw_time);
+        char time_str[20]; // "YYYY:MM:DD HH:MM:SS"
+        strftime(time_str, sizeof(time_str), "%Y:%m:%d %H:%M:%S", time_info);
+
+        // Write Date/Time to EXIF
+        exifData["Exif.Photo.DateTimeOriginal"] = std::string(time_str);
+
+        // Write GPS data
+        exifData["Exif.GPSInfo.GPSLatitudeRef"] = latitude >= 0 ? "N" : "S";
+        exifData["Exif.GPSInfo.GPSLatitude"] = Exiv2::Rational(abs(latitude), 1);
+        exifData["Exif.GPSInfo.GPSLongitudeRef"] = longitude >= 0 ? "E" : "W";
+        exifData["Exif.GPSInfo.GPSLongitude"] = Exiv2::Rational(abs(longitude), 1);
+        exifData["Exif.GPSInfo.GPSAltitudeRef"] = 0; // 0 = above sea level, 1 = below sea level
+        exifData["Exif.GPSInfo.GPSAltitude"] = Exiv2::Rational(static_cast<int>(altitude * 100), 100);
+
+        // Write DOP (Dilution of Precision)
+        double dop = 5.0; // Default value
+        exifData["Exif.GPSInfo.GPSDOP"] = Exiv2::Rational(static_cast<int>(dop * 100), 100);
+
+        image->setExifData(exifData);
+        image->writeMetadata();
+    } catch (const Exiv2::AnyError& e) {
+        std::cerr << "EXIF writing error: " << e.what() << std::endl;
+    }
+}
 
 int main(int argc, char * argv[])
 {
@@ -18,15 +63,25 @@ int main(int argc, char * argv[])
 
     std::string video_file, frame_id, camera_info_file;
     bool bag_sync = true;
+    int splat_fps;
     node->declare_parameter("video_file", video_file);
     node->declare_parameter("frame_id", frame_id);
     node->declare_parameter("bag_sync", bag_sync);
     node->declare_parameter("camera_info_file", camera_info_file);
+    node->declare_parameter("splat_fps", splat_fps);
 
     node->get_parameter("video_file", video_file);
     node->get_parameter("frame_id", frame_id);
     node->get_parameter("bag_sync", bag_sync);
     node->get_parameter("camera_info_file", camera_info_file);
+    node->get_parameter("splat_fps", splat_fps);
+
+    rclcpp::Client<messages_88::srv::Geopoint>::SharedPtr geo_client_ = node->create_client<messages_88::srv::Geopoint>("/task_manager/slam2geo");
+    // Ensure service client is available
+    if (!geo_client_->wait_for_service(std::chrono::seconds(10))) {
+        RCLCPP_ERROR(node->get_logger(), "Geo service unavailable, skipping EXIF.");
+        return 1;
+    }
 
     if (bag_sync) {
         RCLCPP_INFO(node->get_logger(), "Waiting for IMU message to start video publishing");
@@ -57,6 +112,7 @@ int main(int argc, char * argv[])
         RCLCPP_ERROR(node->get_logger(), "Error opening video file");
         return 1;
     }
+
     double fps = cap.get(cv::CAP_PROP_FPS);
     int frame_count = 0;
     rclcpp::Time start_time = node->get_clock()->now();
@@ -79,26 +135,21 @@ int main(int argc, char * argv[])
         // Convert tm to time_t
         std::time_t time = std::mktime(&tm);
         start_time = rclcpp::Time(time, 0); // Need to get fractional seconds storing
-        std::cout << "starting time was " << start_time.seconds() << " sec" << std::endl;
     }
 
     // Load camera info
     std::string camera_info_url = "file://" + camera_info_file;
     std::string camera_name = "mp4";
     sensor_msgs::msg::CameraInfo camera_info_;
-    camera_calibration_parsers::readCalibration( camera_info_url, camera_name, camera_info_);
+    camera_calibration_parsers::readCalibration(camera_info_url, camera_name, camera_info_);
 
     // TF2 buffer and listener
     tf2_ros::Buffer tf_buffer(node->get_clock());
     tf2_ros::TransformListener tf_listener(tf_buffer);
 
-    // Open file to write camera positions
-    std::ofstream pose_file_(base_path + "/camera_positions.txt");
-    if (!pose_file_.is_open()) {
-        RCLCPP_ERROR(node->get_logger(), "Error opening camera_positions.txt");
-    }
-    else {
-        RCLCPP_INFO(node->get_logger(), "Camera positions will be written to %s", (base_path + "camera_positions.txt").c_str());
+    std::string outputDir = base_path + "/camera";
+    if (!std::filesystem::exists(outputDir)) {
+        std::filesystem::create_directory(outputDir);
     }
 
     cv::Mat frame;
@@ -120,24 +171,52 @@ int main(int argc, char * argv[])
             image_msg = cv_bridge::CvImage(header, "bgr8", frame).toImageMsg();
             camera_info_.header = header;
 
+            if (frame_count % splat_fps != 0) {
+                frame_count++;
+                continue;
+            }
+
             // Get the transform from camera to map
             geometry_msgs::msg::TransformStamped transform_stamped;
-            std::string image_name = "image_" + std::to_string(frame_count) + ".png";
             try {
                 transform_stamped = tf_buffer.lookupTransform("map", frame_id, tf2::TimePointZero);
-                pose_file_  << frame_count << " ";
-                pose_file_  << transform_stamped.transform.rotation.w << " " 
-                            << transform_stamped.transform.rotation.x << " "
-                            << transform_stamped.transform.rotation.y << " " 
-                            << transform_stamped.transform.rotation.z << " ";
-                pose_file_  << transform_stamped.transform.translation.x << " " 
-                            << transform_stamped.transform.translation.y << " " 
-                            << transform_stamped.transform.translation.z << " ";
-                pose_file_  << "mp4" << " " << image_name << "\n";
-                pose_file_  << "\n"; // Leave blank line between frames
             } catch (tf2::TransformException &ex) {
                 RCLCPP_WARN(node->get_logger(), "Could not transform %s to map: %s", frame_id.c_str(), ex.what());
+                continue;
             }
+
+            // Get lat/long for image
+            auto geo_request = std::make_shared<messages_88::srv::Geopoint::Request>(); 
+            geo_request->slam_position.x = transform_stamped.transform.translation.x;
+            geo_request->slam_position.y = transform_stamped.transform.translation.y;
+            geo_request->slam_position.z = transform_stamped.transform.translation.z;
+            auto geo_res = geo_client_->async_send_request(geo_request);
+            double lat, lon, home_alt;
+            if (rclcpp::spin_until_future_complete(node, geo_res, 1s) == rclcpp::FutureReturnCode::SUCCESS)
+            {
+                try
+                {
+                    auto response = geo_res.get();
+                    lat = response->latitude;
+                    lon = response->longitude;
+                    home_alt = response->home_altitude;
+                }
+                catch (const std::exception &e)
+                {
+                    RCLCPP_INFO(node->get_logger(), "Geo service call failed, no lat/long available for EXIF data.");
+                }
+            
+            } else {
+                RCLCPP_ERROR(node->get_logger(), "Failed to get lat/long, no EXIF.");
+                continue;
+            }
+
+            // Save image
+            std::string image_name = outputDir + "/image_" + std::to_string(frame_count) + ".png";
+            cv::imwrite(image_name, frame); // Save the frame
+
+            double altitude = transform_stamped.transform.translation.z + home_alt;
+            embedGPSData(image_name, lat, lon, altitude, start_time + t); // Embed GPS data
         } 
         catch (cv_bridge::Exception& e) 
         {
@@ -152,7 +231,6 @@ int main(int argc, char * argv[])
         loop_rate.sleep();
     }
 
-    pose_file_.close();
     rclcpp::shutdown();
     return 0;
 }

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -1,8 +1,10 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/opencv.hpp>
+#include <camera_info_manager/camera_info_manager.hpp>
 #include <sstream>
 
 int main(int argc, char * argv[])
@@ -10,15 +12,17 @@ int main(int argc, char * argv[])
     rclcpp::init(argc, argv);
     auto node = rclcpp::Node::make_shared("mp4_to_ros2");
 
-    std::string video_file, frame_id;
+    std::string video_file, frame_id, camera_info_file;
     bool bag_sync = true;
     node->declare_parameter("video_file", video_file);
     node->declare_parameter("frame_id", frame_id);
     node->declare_parameter("bag_sync", bag_sync);
+    node->declare_parameter("camera_info_file", camera_info_file);
 
     node->get_parameter("video_file", video_file);
     node->get_parameter("frame_id", frame_id);
     node->get_parameter("bag_sync", bag_sync);
+    node->get_parameter("camera_info_file", camera_info_file);
 
     if (bag_sync) {
         RCLCPP_INFO(node->get_logger(), "Waiting for IMU message to start video publishing");
@@ -38,8 +42,10 @@ int main(int argc, char * argv[])
         imu_sub.reset();
     }
 
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher =
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_publisher =
         node->create_publisher<sensor_msgs::msg::Image>("/mp4/video_frames", 10);
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_publisher =
+        node->create_publisher<sensor_msgs::msg::CameraInfo>("/mp4/camera_info", 10);
 
     cv::VideoCapture cap(video_file); 
     if (!cap.isOpened())
@@ -69,8 +75,13 @@ int main(int argc, char * argv[])
         std::cout << "starting time was " << start_time.seconds() << " sec" << std::endl;
     }
 
+    // Load camera info
+    std::string camera_info_url = "file://" + camera_info_file;
+    camera_info_manager::CameraInfoManager cam_info_manager(node.get(), "mp4", camera_info_url);
+    sensor_msgs::msg::CameraInfo::SharedPtr camera_info_msg = std::make_shared<sensor_msgs::msg::CameraInfo>(cam_info_manager.getCameraInfo());
+
     cv::Mat frame;
-    sensor_msgs::msg::Image::SharedPtr msg;
+    sensor_msgs::msg::Image::SharedPtr image_msg;
     rclcpp::WallRate loop_rate(fps); // Adjust the rate as needed
 
     while (rclcpp::ok() && cap.read(frame))
@@ -85,16 +96,18 @@ int main(int argc, char * argv[])
             int sec = floor(timestamp_seconds);
             rclcpp::Duration t(sec, nsec);
             header.stamp = start_time + t;
-            msg = cv_bridge::CvImage(header, "bgr8", frame).toImageMsg();
+            image_msg = cv_bridge::CvImage(header, "bgr8", frame).toImageMsg();
+            camera_info_msg->header = header;
         } 
         catch (cv_bridge::Exception& e) 
         {
             RCLCPP_ERROR(node->get_logger(), "cv_bridge exception: %s", e.what());
             return 1;
         }
-        frame_count ++;
+        frame_count++;
 
-        publisher->publish(*msg);
+        image_publisher->publish(*image_msg);
+        camera_info_publisher->publish(*camera_info_msg);
         rclcpp::spin_some(node);
         loop_rate.sleep();
     }

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -61,11 +61,12 @@ int main(int argc, char * argv[])
     rclcpp::init(argc, argv);
     auto node = rclcpp::Node::make_shared("mp4_to_ros2");
 
-    std::string video_file, frame_id, camera_info_file;
+    std::string video_file, frame_id, camera_info_file, camera_name;
     bool bag_sync = true, save_splat_images = false;
     int splat_fps;
     node->declare_parameter("video_file", video_file);
     node->declare_parameter("frame_id", frame_id);
+    node->declare_parameter("camera_name", camera_name);
     node->declare_parameter("bag_sync", bag_sync);
     node->declare_parameter("camera_info_file", camera_info_file);
     node->declare_parameter("save_splat_images", save_splat_images);
@@ -73,6 +74,7 @@ int main(int argc, char * argv[])
 
     node->get_parameter("video_file", video_file);
     node->get_parameter("frame_id", frame_id);
+    node->get_parameter("camera_name", camera_name);
     node->get_parameter("bag_sync", bag_sync);
     node->get_parameter("camera_info_file", camera_info_file);
     node->get_parameter("save_splat_images", save_splat_images);
@@ -104,9 +106,9 @@ int main(int argc, char * argv[])
     }
 
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_publisher =
-        node->create_publisher<sensor_msgs::msg::Image>("/mp4/image_raw", 10);
+        node->create_publisher<sensor_msgs::msg::Image>(camera_name + "/image_raw", 10);
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_publisher =
-        node->create_publisher<sensor_msgs::msg::CameraInfo>("/mp4/camera_info", 10);
+        node->create_publisher<sensor_msgs::msg::CameraInfo>(camera_name + "/camera_info", 10);
 
     cv::VideoCapture cap(video_file); 
     if (!cap.isOpened())
@@ -141,7 +143,6 @@ int main(int argc, char * argv[])
 
     // Load camera info
     // std::string camera_info_url = camera_info_file;
-    std::string camera_name = "mp4";
     sensor_msgs::msg::CameraInfo camera_info_;
     camera_calibration_parsers::readCalibration(camera_info_file, camera_name, camera_info_);
 
@@ -149,7 +150,7 @@ int main(int argc, char * argv[])
     tf2_ros::Buffer tf_buffer(node->get_clock());
     tf2_ros::TransformListener tf_listener(tf_buffer);
 
-    std::string outputDir = base_path + "/camera";
+    std::string outputDir = base_path + "/" + camera_name + "_images";
     if (!std::filesystem::exists(outputDir)) {
         std::filesystem::create_directory(outputDir);
     }


### PR DESCRIPTION
Waits for IMU topic now before playback to sync it with ROS bags. Also optionally saves images to a folder with EXIF data for making splats.

Related prs
- [ ] [vehiclelaunch](https://github.com/robotics-88/vehicle-launch/pull/59)
- [ ] [taskmanager](https://github.com/robotics-88/task-manager/pull/65)
- [ ] [rosmessages](https://github.com/robotics-88/ros-messages-88/pull/13)
- [ ] [distal](https://github.com/robotics-88/distal/pull/21)

Repo file: 
[bagsync.txt](https://github.com/user-attachments/files/19299705/bagsync.txt)


## Test on bag
Run with
```
ros2 launch vehicle_launch offline.launch
```
Open foxglove, and confirm that these topics are publishing and appear synced:

- /gopro/image_raw
- /gopro/image_color
- /cloud_registered_map

Like so:
![Screenshot from 2025-03-17 18-46-41](https://github.com/user-attachments/assets/3bf6b9b2-fbfb-4b2b-8216-035e9d785b58)

