### PR TITLE
Bugfix/exif and fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # mp4-to-ros2
 
-Simple ROS2 node to read in an mp4 with OpenCV and publish frames as image messages. If the mp4 filename is a date-time, it will publish images with timestamps beginning from this timestamp using FPS to estimate each frame stamp. Otherwise, it starts at the current time.
+Simple ROS2 node to read in an mp4 with OpenCV and publish frames as image messages. If the mp4 filename is a date-time, it will publish images with timestamps beginning from this timestamp using FPS to estimate each frame stamp. Otherwise, it starts at the timestamp from the latest IMU message.
+
+## Data cleaning
+
+If the video was recorded automatically at arming, great! Otherwise, trim the video to match the moment the props arm. To reduce the framerate, downsample the video prior to launch with:
+```
+ffmpeg -i in.mp4 -vf fps=5 out.mp4
+```

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -5,7 +5,7 @@
 
     <arg name="bag_sync" default="true"/>
     <arg name="camera_info_file" default="camera_info.yaml"/>
-    <arg name="save_splat_images" default="true"/>
+    <arg name="save_splat_images" default="false"/>
     <arg name="splat_fps" default="5"/>
 
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">

--- a/launch/mp4.launch
+++ b/launch/mp4.launch
@@ -5,7 +5,7 @@
 
     <arg name="bag_sync" default="true"/>
     <arg name="camera_info_file" default="camera_info.yaml"/>
-    <arg name="save_splat_images" default="false"/>
+    <arg name="save_splat_images" default="true"/>
     <arg name="splat_fps" default="5"/>
 
     <node pkg="mp4_to_ros2" exec="mp4_node" output="screen">

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,11 @@
   <depend>sensor_msgs</depend>
   <depend>messages_88</depend>
 
+  <depend>libexiv2-dev</depend>
+  <depend>libimage-exiftool-perl</depend>
+  <depend>exiv2</depend>
+  <depend>libexif-dev</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -107,7 +107,9 @@ void embedGPSData(const std::string& imagePath, double latitude, double longitud
         exifData["Exif.GPSInfo.GPSLongitudeRef"] = longitude >= 0 ? "E" : "W";
 
         // Write altitude data
-        exifData["Exif.GPSInfo.GPSAltitudeRef"] = 0; // 0 = above sea level, 1 = below sea level
+        Exiv2::Value::AutoPtr altRef = Exiv2::Value::create(Exiv2::unsignedByte);
+        altRef->read("0");  // "0" indicates above sea level
+        exifData["Exif.GPSInfo.GPSAltitudeRef"] = *altRef;  // Dereference here
         exifData["Exif.GPSInfo.GPSAltitude"] = Exiv2::Rational(static_cast<int>(altitude * 100), 100);
 
         // Write DOP (Dilution of Precision)
@@ -266,7 +268,7 @@ int main(int argc, char * argv[])
                             // RCLCPP_INFO(node->get_logger(), "Got lat/long for image: %f, %f. Home: %f", lat, lon, home_alt);
 
                             // Save image
-                            std::string image_name = outputDir + "/image_" + std::to_string(frame_count) + ".png";
+                            std::string image_name = outputDir + "/image_" + std::to_string(frame_count) + ".jpg";
                             cv::imwrite(image_name, frame); // Save the frame
             
                             double altitude = transform_stamped.transform.translation.z + home_alt;

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -250,7 +250,7 @@ int main(int argc, char * argv[])
                             auto response = geo_res.get();
                             lat = response->latitude;
                             lon = response->longitude;
-                            home_alt = 1215.2239024774262; //response->home_altitude;
+                            home_alt = response->home_altitude;
                             // RCLCPP_INFO(node->get_logger(), "Got lat/long for image: %f, %f. Home: %f", lat, lon, home_alt);
 
                             // Save image

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -18,20 +18,6 @@
 
 using namespace std::chrono_literals;
 
-std::vector<Exiv2::Rational> convertToDMS(double decimalDegree) {
-    double absVal = std::fabs(decimalDegree);
-    int degrees = static_cast<int>(absVal);
-    double fractional = absVal - degrees;
-    int minutes = static_cast<int>(fractional * 60);
-    double seconds = (fractional * 60 - minutes) * 60;
-    // Using a factor (here 100) to preserve decimals; adjust as needed
-    return {
-        Exiv2::Rational(degrees, 1),
-        Exiv2::Rational(minutes, 1),
-        Exiv2::Rational(static_cast<int>(seconds * 100), 100)
-    };
-}
-
 void embedGPSData(const std::string& imagePath, double latitude, double longitude, double altitude, rclcpp::Time timestamp) {
     try {
         Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(imagePath);


### PR DESCRIPTION
Adds option to save splat images with EXIF data for geotagging. Test with [vehicle_launch](https://github.com/robotics-88/vehicle-launch/pull/64) PR too.

## Test
Take the bird museum data. Folder should be as usual, flight_dir contains the video and bag/bag_0.mcap, run it with:
```
ros2 launch vehicle_launch offline.launch save_splat_images:=true flight_dir:=<full path to flight dir containing video.mp4 and bag/bag.mcap>
```
Note the correct bird museum video is called birdstart1.mp4.

If successful, this should create a folder called mp4_images under flight_dir, with many images in it. Don't need to run the full bag, just verify it's creating images here.